### PR TITLE
Update gnome profile with missing package

### DIFF
--- a/editions/gnome
+++ b/editions/gnome
@@ -12,6 +12,7 @@ man-pages
 man-db
 zswap-arm
 
+
 # Sound, video and bluetooth
 pavucontrol
 pulseaudio-alsa
@@ -28,6 +29,7 @@ libva-v4l2-request
 
 # Display Manager
 gdm
+xf86-video-fbdev
 
 # Network
 avahi


### PR DESCRIPTION
X needs fbdev to display something on the screen. This package does not seem to be installed through a dependency